### PR TITLE
imroved CSS (padding) and fixed back links

### DIFF
--- a/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Styles/styles.css
+++ b/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Styles/styles.css
@@ -14,13 +14,8 @@ td {
     padding: 1em;
 }
 
-:target {
-    border: 1px dotted blue;
-}
-
-
-summary {
-    border: 1px solid silver;
+thead td {
+    font-weight: bold;
 }
 
 caption, .caption, figcaption {
@@ -29,31 +24,51 @@ caption, .caption, figcaption {
     text-align: left;
 }
 
-thead td {
-    font-weight: bold;
-}
-
-a:focus, a:active, a:hover {
+a:focus, a:active, a:hover, details > summary:focus {
   outline-width: 1px;
   outline-style: dashed;
   outline-color: red;
+  outline-offset: 0.1em;
+}
+
+:target {
+  /* border: 2px solid black; */
+
+  outline-width: 2px;
+  outline-style: solid;
+  outline-color: black;
+  outline-offset: 0.2em;
+}
+
+details > summary {
+    border: 1px solid silver;
+    padding: 0.3em;
+}
+
+details > div {
+    padding: 1em;
+}
+
+details[open] {
+    /* border: 2px solid black; */
+  
+    outline-width: 2px;
+    outline-style: solid;
+    outline-color: black;
+    outline-offset: 0em;
 }
 
 aside.extendedDescription  {
 /*  position: absolute; */
-  height: 1px;
-  width: 1px;
-  clip: rect(1px 1px 1px 1px);
-  clip: rect(1px,1px,1px,1px);
-  clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px);
-  -webkit-clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px);
-  overflow: hidden!important;
+    height: 1px;
+    width: 1px;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px,1px,1px,1px);
+    clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px);
+    -webkit-clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px);
+    overflow: hidden!important;
 }
 
-:target {
-  border: 2px solid black;
-}
-
-details[open] {
-    border: 2px solid black;
+.endDesc {
+    padding: 1em;
 }

--- a/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsEndOfChapter.xhtml
+++ b/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsEndOfChapter.xhtml
@@ -83,7 +83,7 @@ document. The extended description is placed under the heading "Example 4: Descr
 
     <h2>End of Chapter Extended Descriptions</h2>
 
-    <div id="image1-extended-desc">
+    <div id="image1-extended-desc" class="endDesc">
         <h3>Example 3: Description of Bar Chart</h3>
         <div>
             <h4>Overview</h4>
@@ -129,14 +129,14 @@ document. The extended description is placed under the heading "Example 4: Descr
                 horizontally, with heights indicating the number of visitors. A fourth column is provided for each website
                 with the accumulated site visitors for the quarter.</p>
             <p>
-                <a href="#image1">Navigate back to Example 3: Bar Chart image.</a>
+                <a href="#image1-link">Navigate back to Example 3: Bar Chart image.</a>
             </p>
         </div>
     </div>
 
     <hr />
 
-    <div id="image2-extended-desc">
+    <div id="image2-extended-desc" class="endDesc">
         <h3>Example 4: Description of Peacock</h3>
 
             <p>
@@ -146,7 +146,7 @@ document. The extended description is placed under the heading "Example 4: Descr
                 have iridescent greenish blue feathers. The back has scaly bronze-green feathers with black and copper markings.
             </p>
             <p>
-                <a href="#image2">Navigate back to Example 4: Peacock image.</a>
+                <a href="#image2-link">Navigate back to Example 4: Peacock image.</a>
             </p>
     </div>
 

--- a/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsEndOfChapterWithFootnoteSemantics.xhtml
+++ b/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsEndOfChapterWithFootnoteSemantics.xhtml
@@ -83,7 +83,7 @@ description is placed under the heading "Example 6: Description of peacock" <br/
 
 <h3>Example 5 extended description using footnote semantics</h3>
 
-    <aside epub:type="footnote" role="doc-footnote" id="image1-extended-desc">
+    <aside epub:type="footnote" role="doc-footnote" id="image1-extended-desc" class="endDesc">
         <h3>Example 5: Description of Bar Chart</h3>
         <div>
             <h4>Overview</h4>
@@ -129,14 +129,14 @@ description is placed under the heading "Example 6: Description of peacock" <br/
                 horizontally, with heights indicating the number of visitors. A fourth column is provided for each website
                 with the accumulated site visitors for the quarter.</p>
             <p>
-                <a epub:type="backlink" role="doc-backlink" href="#image1">Navigate back to description link of Example 5: Bar Chart image.</a>
+                <a epub:type="backlink" role="doc-backlink" href="#image1-link">Navigate back to description link of Example 5: Bar Chart image.</a>
             </p>
         </div>
     </aside>
 <h3>Example 6 using aside and epub footnote semantics</h3>
 
 
-    <aside epub:type="footnote" role="doc-footnote" id="image2-extended-desc">
+    <aside epub:type="footnote" role="doc-footnote" id="image2-extended-desc" class="endDesc">
         <h3>Example 6: Description of Peacock</h3>
         <div>
             <p>
@@ -146,7 +146,7 @@ description is placed under the heading "Example 6: Description of peacock" <br/
                 have iridescent greenish blue feathers. The back has scaly bronze-green feathers with black and copper markings.
             </p>
             <p>
-                <a epub:type="backlink" role="doc-backlink" href="#image2">Navigate back to description link of Example 6: Peacock image.</a>
+                <a epub:type="backlink" role="doc-backlink" href="#image2-link">Navigate back to description link of Example 6: Peacock image.</a>
             </p>
         </div>
     </aside>

--- a/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsUnderImage.xhtml
+++ b/ExtendedDescriptions/image-descriptions-testbook/ExtendedDescriptionsTestBook/OEBPS/Text/testDetailsUnderImage.xhtml
@@ -38,7 +38,7 @@ Test passes if following steps are successful:<br/>
         <figcaption>
             Example.com Site visitors Jan to March 2014
 
-            <details class="extendedDescription" id="image1-extended-desc">
+            <details id="image1-extended-desc">
                 <summary>Expand / collapse description</summary>
                 <div>
                     <h3>Overview</h3>
@@ -107,7 +107,7 @@ Test passes if following steps are successful:<br/>
     <p>In this example, the head of the peacock is described using a paragraph of text that is on the web page.</p>
 
     <img src="../Images/peafowl-998cf337.jpg" alt="Male peacock head" aria-details="#image2-extended-desc" />
-    <details class="extendedDescription" id="image2-extended-desc">
+    <details id="image2-extended-desc">
         <summary>Expand / collapse description</summary>
         <div>
             <p>


### PR DESCRIPTION
Added padding in details summary and content, as well as in link targets (such as end of chapter descriptions), and also around keyboard focused outlines (such as hyperlinks). In addition, back-links now target the source originating link, not the described object / image.